### PR TITLE
Lightweight single-node Airflow for Onehouse SQL orchestration

### DIFF
--- a/lightweight-airflow/.env.example
+++ b/lightweight-airflow/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env and fill in values
+
+# Airflow admin credentials
+AIRFLOW_USER=admin
+AIRFLOW_PASSWORD=admin
+AIRFLOW_SECRET_KEY=change-me-to-a-long-random-string
+
+# Onehouse SQL / Spark Thrift Server
+# Local dev (Mac): use host.docker.internal (SSM tunnel on your Mac's localhost)
+# EC2 deployment: use the internal DNS/IP of the Spark Thrift Server directly
+#   e.g. <internal-elb-dns>.us-west-2.elb.amazonaws.com
+HIVE_HOST=host.docker.internal
+HIVE_PORT=10000
+HIVE_USER=hive
+HIVE_PASSWORD=hive

--- a/lightweight-airflow/.gitignore
+++ b/lightweight-airflow/.gitignore
@@ -1,0 +1,4 @@
+.env
+logs/
+__pycache__/
+*.pyc

--- a/lightweight-airflow/Dockerfile
+++ b/lightweight-airflow/Dockerfile
@@ -1,0 +1,19 @@
+FROM apache/airflow:2.10.5
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libsasl2-dev \
+    libsasl2-modules \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER airflow
+
+# Install providers using Airflow's constraints file to prevent pip from
+# upgrading airflow itself (latest hive provider 9.x requires Airflow 3.x)
+RUN pip install --no-cache-dir \
+    apache-airflow-providers-apache-hive \
+    apache-airflow-providers-common-sql \
+    "pyhive[hive_pure_sasl]" \
+    --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt"

--- a/lightweight-airflow/README.md
+++ b/lightweight-airflow/README.md
@@ -1,0 +1,110 @@
+# Lightweight Airflow for Onehouse SQL
+
+Single-node Airflow running in Docker — a minimal alternative to MWAA for orchestrating Onehouse SQL (Spark Thrift Server).
+
+**Stack:** Airflow 2.10 + LocalExecutor + Postgres. No Celery, no Redis.
+**RAM:** ~1.5 GB total at idle.
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│  Docker Compose                     │
+│                                     │
+│  ┌──────────────┐  ┌─────────────┐  │
+│  │  airflow     │  │  postgres   │  │
+│  │  scheduler   │  │  (metadata) │  │
+│  │  webserver   │  │             │  │
+│  │  LocalExec   │  │             │  │
+│  └──────┬───────┘  └─────────────┘  │
+│         │ hive2://                  │
+└─────────┼───────────────────────────┘
+          │ (SSM tunnel on Mac / direct VPC on EC2)
+          ▼
+    Spark Thrift Server :10000
+    (Onehouse SQL)
+```
+
+## Quickstart (local Mac)
+
+```bash
+# 1. Configure environment
+cp .env.example .env
+# Edit .env if needed (defaults work with the standard SSM tunnel setup)
+
+# 2. Open a tunnel to Onehouse SQL on port 10000
+# Option A — SSM (no SSH key required):
+aws ssm start-session \
+  --region us-west-2 \
+  --target <thrift-server-instance-id> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<thrift-server-internal-elb-dns>"],"portNumber":["10000"],"localPortNumber":["10000"]}' &
+
+# Option B — SSH (requires key access to a bastion/jump host):
+ssh -N -L 10000:<thrift-server-internal-elb-dns>:10000 <user>@<bastion-host> &
+
+# 3. Build and start
+docker compose up --build -d
+
+# 4. Open UI
+open http://localhost:8080
+# Login: admin / admin (or whatever you set in .env)
+```
+
+> Note: DAGs are paused by default on first import. Unpause before triggering:
+> ```bash
+> docker compose exec scheduler airflow dags unpause onehouse_sql_example
+> ```
+
+## Onehouse SQL Connection
+
+Pre-configured via environment variable in `docker-compose.yml`:
+
+```
+conn_id: onehouse_sql
+type: hiveserver2
+host: host.docker.internal   # resolves to your Mac's localhost from inside Docker
+port: 10000
+auth: NOSASL
+```
+
+To override, set `HIVE_HOST`, `HIVE_PORT`, `HIVE_USER`, `HIVE_PASSWORD` in `.env`.
+
+You can also manage connections through the Airflow UI at Admin > Connections.
+
+## Writing DAGs
+
+```python
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+
+run_query = SQLExecuteQueryOperator(
+    task_id="run_query",
+    conn_id="onehouse_sql",
+    sql="SELECT COUNT(*) FROM my_db.my_table",
+)
+```
+
+See `dags/onehouse_sql_example.py` for a full example.
+
+## Useful Commands
+
+```bash
+# View logs
+docker compose logs -f scheduler
+
+# Stop everything (keeps data)
+docker compose down
+
+# Stop and wipe metadata DB
+docker compose down -v
+
+# Restart just the scheduler
+docker compose restart scheduler
+
+# Trigger a DAG manually
+docker compose exec scheduler airflow dags trigger onehouse_sql_example
+```
+
+## EC2 Deployment
+
+See [vm/AL_EC2_README.md](vm/AL_EC2_README.md).

--- a/lightweight-airflow/dags/onehouse_sql_example.py
+++ b/lightweight-airflow/dags/onehouse_sql_example.py
@@ -1,0 +1,80 @@
+"""
+Example DAG: Run SQL against Onehouse SQL (Spark Thrift Server).
+
+Connection used: AIRFLOW_CONN_ONEHOUSE_SQL
+  hiveserver2://hive:hive@host.docker.internal:10000/default?auth=NOSASL
+
+Prerequisites:
+  - SSM tunnel forwarding port 10000 to the Spark Thrift Server must be active
+  - See .env.example for connection configuration
+"""
+
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+
+# To log query results directly in the task log, use a PythonOperator with
+# HiveServer2Hook instead of SQLExecuteQueryOperator:
+#
+# import logging
+# from airflow.operators.python import PythonOperator
+# from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
+#
+# def run_and_log(sql, conn_id="onehouse_sql"):
+#     log = logging.getLogger(__name__)
+#     hook = HiveServer2Hook(hiveserver2_conn_id=conn_id)
+#     cursor = hook.get_conn().cursor()
+#     cursor.execute(sql)
+#     rows = cursor.fetchall()
+#     cols = [d[0] for d in cursor.description] if cursor.description else []
+#     log.info("columns: %s", cols)
+#     for row in rows:
+#         log.info("row: %s", row)
+#     log.info("total rows: %d", len(rows))
+#     return rows
+#
+# show_databases = PythonOperator(
+#     task_id="show_databases",
+#     python_callable=run_and_log,
+#     op_kwargs={"sql": "SHOW DATABASES"},
+# )
+
+default_args = {
+    "owner": "onehouse",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="onehouse_sql_example",
+    default_args=default_args,
+    description="Example: run SQL queries against Onehouse SQL",
+    schedule="@daily",
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["onehouse", "sql"],
+) as dag:
+
+    # Simple connectivity check
+    check_connection = SQLExecuteQueryOperator(
+        task_id="check_connection",
+        conn_id="onehouse_sql",
+        sql="SELECT 1",
+    )
+
+    # List databases
+    show_databases = SQLExecuteQueryOperator(
+        task_id="show_databases",
+        conn_id="onehouse_sql",
+        sql="SHOW DATABASES",
+    )
+
+    # Example: run a real query — swap in your table name
+    # sample_query = SQLExecuteQueryOperator(
+    #     task_id="sample_query",
+    #     conn_id="onehouse_sql",
+    #     sql="SELECT COUNT(*) FROM my_database.my_table",
+    # )
+
+    check_connection >> show_databases

--- a/lightweight-airflow/docker-compose.yml
+++ b/lightweight-airflow/docker-compose.yml
@@ -1,0 +1,73 @@
+x-airflow-common: &airflow-common
+  build: .
+  environment:
+    AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__CORE__PARALLELISM: "8"
+    AIRFLOW__WEBSERVER__SECRET_KEY: ${AIRFLOW_SECRET_KEY:-change-me-in-production}
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+
+    # Onehouse SQL connection (Spark Thrift Server / HiveServer2)
+    # Override host/port via .env if your tunnel uses different settings
+    AIRFLOW_CONN_ONEHOUSE_SQL: >-
+      hiveserver2://${HIVE_USER:-hive}:${HIVE_PASSWORD:-hive}@${HIVE_HOST:-host.docker.internal}:${HIVE_PORT:-10000}/default?auth=NOSASL
+
+  volumes:
+    - ./dags:/opt/airflow/dags
+    - ./logs:/opt/airflow/logs
+    - ./plugins:/opt/airflow/plugins
+  # Needed for local Mac dev only (SSM tunnel on host's localhost).
+  # On EC2, set HIVE_HOST to the internal DNS of the Spark Thrift Server
+  # and remove or ignore this — containers reach it directly via VPC.
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  depends_on:
+    postgres:
+      condition: service_healthy
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 5s
+      retries: 5
+
+  airflow-init:
+    <<: *airflow-common
+    user: "0:0"
+    command: bash -c "mkdir -p /opt/airflow/logs /opt/airflow/plugins && chown -R 50000:0 /opt/airflow/logs /opt/airflow/plugins && airflow db migrate && airflow users create --username ${AIRFLOW_USER:-admin} --password ${AIRFLOW_PASSWORD:-admin} --firstname Admin --lastname User --role Admin --email admin@example.com || true"
+    restart: "no"
+
+  scheduler:
+    <<: *airflow-common
+    command: airflow scheduler
+    restart: unless-stopped
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+
+  webserver:
+    <<: *airflow-common
+    command: airflow webserver
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/lightweight-airflow/vm/AL_EC2_README.md
+++ b/lightweight-airflow/vm/AL_EC2_README.md
@@ -1,0 +1,101 @@
+# Deploying on Amazon Linux 2023 EC2
+
+## Prerequisites
+
+- EC2 instance running **Amazon Linux 2023**
+- Instance in the same VPC as the Onehouse SQL Spark Thrift Server
+- Security group rules:
+  - Outbound port `10000` to the Thrift Server's security group
+  - Inbound port `8080` not required — access the UI via SSM port forward (see below)
+- Recommended instance size: `t2.medium` or `t3.medium` (4 GB RAM)
+
+## Bootstrap (fresh instance)
+
+Copy the `lightweight-airflow/` folder onto the instance (e.g. via `scp` or by pulling from the repo), then run from the `vm/` directory:
+
+```bash
+sudo HIVE_HOST="<internal-thrift-server-dns>" \
+     AIRFLOW_PASSWORD="<strong-password>" \
+     bash al_ec2.sh
+```
+
+The script will:
+1. Install Docker and Docker Compose
+2. Install Docker Buildx (required for `docker compose build`)
+3. Add `ec2-user` and `ssm-user` to the `docker` group
+4. Write `.env` with the provided values
+5. Build and start the stack
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `HIVE_HOST` | internal ELB DNS | Internal DNS/IP of the Spark Thrift Server |
+| `HIVE_PORT` | `10000` | Thrift Server port |
+| `HIVE_USER` | `hive` | Thrift Server user |
+| `HIVE_PASSWORD` | `hive` | Thrift Server password |
+| `AIRFLOW_USER` | `admin` | Airflow UI username |
+| `AIRFLOW_PASSWORD` | `admin` | Airflow UI password — **change this** |
+| `AIRFLOW_SECRET_KEY` | random | Webserver secret key — auto-generated if not set |
+
+## Accessing the UI
+
+**Option A — SSM (no SSH key required):**
+
+```bash
+aws ssm start-session \
+  --region us-west-2 \
+  --target <instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"]}'
+```
+
+**Option B — SSH tunnel (requires key access):**
+
+```bash
+ssh -N -L 8080:localhost:8080 <user>@<instance-ip-or-bastion>
+```
+
+Then open `http://localhost:8080`.
+
+## After bootstrap
+
+```bash
+cd lightweight-airflow
+
+# Check containers
+docker compose ps
+
+# Follow logs
+docker compose logs -f
+
+# Trigger a DAG manually
+docker compose exec scheduler airflow dags trigger onehouse_sql_example
+```
+
+> DAGs are paused by default on first import. Unpause before triggering:
+> ```bash
+> docker compose exec scheduler airflow dags unpause onehouse_sql_example
+> ```
+
+## Deploying DAG updates
+
+```bash
+git pull
+# The scheduler picks up DAG file changes automatically — no restart needed.
+# For docker-compose.yml or Dockerfile changes:
+docker compose up --build -d
+```
+
+## If containers don't come back after a reboot
+
+Docker and the containers are configured to start on boot, but if Postgres doesn't come up in time the other containers may start without it. Just run:
+
+```bash
+cd lightweight-airflow && docker compose up -d
+```
+
+## Notes
+
+- The `.env` file lives in the `lightweight-airflow/` root and is gitignored
+- Postgres data is stored in a Docker volume on the instance's EBS root volume — if you replace the instance, DAG run history is lost. Acceptable for a demo/lightweight setup.

--- a/lightweight-airflow/vm/al_ec2.sh
+++ b/lightweight-airflow/vm/al_ec2.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Bootstrap script for Amazon Linux 2023
+# Sets up lightweight Airflow for Onehouse SQL on a single EC2 instance
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+# Path to the lightweight-airflow directory on this instance.
+# Run this script from within that directory, or set AIRFLOW_DIR explicitly.
+AIRFLOW_DIR="${AIRFLOW_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Onehouse SQL — set to the internal ELB DNS or IP of the Spark Thrift Server
+HIVE_HOST="${HIVE_HOST:-}"  # Set via env var: HIVE_HOST="<internal-elb-dns>" bash al_ec2.sh
+HIVE_PORT="${HIVE_PORT:-10000}"
+HIVE_USER="${HIVE_USER:-hive}"
+HIVE_PASSWORD="${HIVE_PASSWORD:-hive}"
+
+AIRFLOW_USER="${AIRFLOW_USER:-admin}"
+AIRFLOW_PASSWORD="${AIRFLOW_PASSWORD:-admin}"
+# Generate a random secret key if not provided
+AIRFLOW_SECRET_KEY="${AIRFLOW_SECRET_KEY:-$(openssl rand -hex 32)}"
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "==> Installing Docker"
+dnf update -y
+dnf install -y docker
+
+echo "==> Installing Docker Compose plugin"
+mkdir -p /usr/local/lib/docker/cli-plugins
+curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64" \
+    -o /usr/local/lib/docker/cli-plugins/docker-compose
+chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+echo "==> Installing Docker Buildx plugin"
+BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+curl -SL "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64" \
+    -o /usr/local/lib/docker/cli-plugins/docker-buildx
+chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+
+echo "==> Starting Docker and enabling on boot"
+systemctl enable --now docker
+usermod -aG docker ec2-user
+usermod -aG docker ssm-user
+
+echo "==> Using AIRFLOW_DIR=$AIRFLOW_DIR"
+
+echo "==> Writing .env"
+cat > "$AIRFLOW_DIR/.env" <<EOF
+AIRFLOW_USER=$AIRFLOW_USER
+AIRFLOW_PASSWORD=$AIRFLOW_PASSWORD
+AIRFLOW_SECRET_KEY=$AIRFLOW_SECRET_KEY
+
+HIVE_HOST=$HIVE_HOST
+HIVE_PORT=$HIVE_PORT
+HIVE_USER=$HIVE_USER
+HIVE_PASSWORD=$HIVE_PASSWORD
+EOF
+
+echo "==> Starting Airflow"
+cd "$AIRFLOW_DIR"
+mkdir -p logs plugins
+chown -R 50000:0 logs plugins
+docker compose up --build -d
+
+echo ""
+echo "✓ Done. Airflow is starting up."
+echo "  UI will be available at http://$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):8080"
+echo "  Login: $AIRFLOW_USER / $AIRFLOW_PASSWORD"
+echo ""
+echo "  To follow startup logs: docker compose -f $AIRFLOW_DIR/docker-compose.yml logs -f"


### PR DESCRIPTION
## Summary

- Two-container Docker setup (Airflow 2.10 + Postgres, LocalExecutor) as a lightweight alternative to MWAA
- No Celery, no Redis — ~1.5GB RAM at idle
- Pre-wired to connect to Onehouse SQL via HiveServer2/Spark Thrift Server
- Connection configured via env var, works with SSM tunnel locally and direct VPC on EC2
- Includes EC2/Amazon Linux 2023 bootstrap script and deployment readme
- Example DAG with `SQLExecuteQueryOperator` and commented pattern for logging results

## Test plan

- [x] Tested locally on Mac with SSM tunnel to Onehouse SQL
- [x] Tested on EC2 (t2.medium, Amazon Linux 2023) with direct VPC access
- [x] Scanned for sensitive/confidential info — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)