### PR TITLE
Add apache-airflow-providers-onehouse to lightweight-airflow

### DIFF
--- a/lightweight-airflow/Dockerfile
+++ b/lightweight-airflow/Dockerfile
@@ -15,5 +15,6 @@ USER airflow
 RUN pip install --no-cache-dir \
     apache-airflow-providers-apache-hive \
     apache-airflow-providers-common-sql \
+    apache-airflow-providers-onehouse \
     "pyhive[hive_pure_sasl]" \
     --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt"


### PR DESCRIPTION
## Summary
- Adds `apache-airflow-providers-onehouse` to the pip install block in the lightweight-airflow Dockerfile

## Test plan
- [x] Rebuild the Docker image and verify the provider installs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)